### PR TITLE
Fixed issue where some tags were not extracted properly.

### DIFF
--- a/Jellyfin.Plugin.MusicTags/MusicTagService.cs
+++ b/Jellyfin.Plugin.MusicTags/MusicTagService.cs
@@ -30,6 +30,9 @@ public class MusicTagService(
     /// Comprehensive mapping of friendly tag names to their ID3v2 frame identifiers.
     /// This allows users to use intuitive names (e.g., "FILETYPE") that work consistently
     /// across file formats, automatically translating to the correct ID3v2 frame ID (e.g., "TFLT").
+    /// 
+    /// Note: Some entries are intentional aliases (e.g., "KEY" and "INITIALKEY" both map to "TKEY")
+    /// to provide flexibility and support different tagging conventions.
     /// </summary>
     private static readonly Dictionary<string, string> TagNameToFrameId = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -114,13 +117,13 @@ public class MusicTagService(
         // Check for matching double quotes
         if (value.StartsWith("\"") && value.EndsWith("\""))
         {
-            return value.Substring(1, value.Length - 2);
+            return value[1..^1];
         }
 
         // Check for matching single quotes
         if (value.StartsWith("'") && value.EndsWith("'"))
         {
-            return value.Substring(1, value.Length - 2);
+            return value[1..^1];
         }
 
         // No matching quotes, return as-is


### PR DESCRIPTION
- Introduced a static dictionary to map user-friendly tag names to their corresponding ID3v2 frame IDs, enhancing usability and consistency across file formats.
- Updated tag extraction methods to utilize the new mapping, allowing for intuitive tag name usage.
- Improved logging by stripping quotes from tag values during extraction for cleaner output.
- Added a new method to extract TXXX frames for custom tags in MP3/WAV files, expanding the tag extraction capabilities.

## Summary by Sourcery

Enhance tag extraction by introducing a friendly-name to frame-ID mapping, extending support for custom TXXX frames, and cleaning up logged tag values

New Features:
- Add TagNameToFrameId dictionary to map friendly tag names to ID3v2 frame IDs
- Implement extraction of custom tags from TXXX user text frames

Enhancements:
- Update tag extraction to try Vorbis comments, TXXX frames, mapped frame IDs, direct IDs, then generic extraction
- Strip enclosing quotes from extracted tag values for cleaner logs