### PR TITLE
Added support for custom tags in wma and m4a audio files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ The plugin supports extraction from multiple audio metadata formats:
 
 ### Audio Format Support
 
-The plugin supports different levels of tag extraction depending on the audio format:
+The plugin supports extraction of custom tags from all major audio formats:
 
 #### ✅ **Full Custom Tag Support**
-These formats support extraction of **any custom tag** you define:
+All these formats support extraction of **any custom tag** you define:
 
 - **MP3** - Standard ID3v2 frames and custom TXXX frames
 - **WAV** - Standard ID3v2 frames and custom TXXX frames (when ID3v2 tags are present)
@@ -95,18 +95,12 @@ These formats support extraction of **any custom tag** you define:
 - **OGG** - Vorbis comments (any custom field name)
 - **OPUS** - Vorbis comments (any custom field name)
 - **WMA** - ASF tags (any custom field name)
+- **M4A/MP4/AAC** - Apple/iTunes freeform tags (any custom field name)
 
 **Example**: You can extract `FILETYPE`, `MOOD`, `LANGUAGE`, `KEY`, `BPM`, or any other custom tag you've added using tools like MP3Tag or MusicBrainz Picard.
 
-#### ⚠️ **Standard Tags Only**
-These formats only support extraction of **standard/predefined tags**:
-
-- **M4A/MP4/AAC** - Standard iTunes metadata tags only (Artist, Album, Genre, Year, Title, etc.)
-
-**M4A Limitation**: Due to limitations in the TagLib-Sharp library (v2.3.0), the plugin cannot access custom tags stored in M4A files by applications like MP3Tag. Only standard iTunes metadata fields are supported. If you need custom tag support, consider using FLAC (lossless) or MP3 (lossy) for those files.
-
 #### 📋 **Standard Tags Available in All Formats**
-All supported formats can extract these standard metadata fields:
+All supported formats can also extract these standard metadata fields:
 - Artist, Album, Genre, Year, Title, Composer, BPM, Publisher, Copyright, Comment
 
 ## How to Install


### PR DESCRIPTION
…tion on limitation for certain audio file types.

- Added detailed sections in README.md outlining audio format support, including custom and standard tag extraction capabilities for various formats.
- Updated MusicTagService to include extraction methods for Apple/iTunes tags (M4A, MP4) and ASF tags (WMA), improving the plugin's versatility in handling different audio file types.
- Enhanced logging for tag extraction processes to provide clearer insights into the values being processed.

## Summary by Sourcery

Implement custom tag extraction for Apple (M4A/MP4/AAC) and ASF (WMA) formats, enhance tag processing and logging, and expand documentation on audio format support

New Features:
- Extract custom Apple/iTunes tags from M4A/MP4/AAC files
- Extract custom ASF tags from WMA files

Enhancements:
- Strip surrounding quotes from split tag values
- Improve logging for tag extraction processes

Documentation:
- Add detailed Audio Format Support section to README, clarifying custom vs standard tag extraction and M4A limitations