### PR TITLE
Properly handle array types for Artists, Performers, and Genres

### DIFF
--- a/Jellyfin.Plugin.MusicTags/MusicTagService.cs
+++ b/Jellyfin.Plugin.MusicTags/MusicTagService.cs
@@ -567,6 +567,18 @@ public class MusicTagService(
                 var value = property.GetValue(file.Tag);
                 if (value != null)
                 {
+                    // Handle array types (e.g. Artists, Performers, Genres return string[])
+                    if (value is string[] stringArray)
+                    {
+                        var joined = string.Join("; ", stringArray.Where(s => !string.IsNullOrEmpty(s)));
+                        if (!string.IsNullOrEmpty(joined))
+                        {
+                            return RemoveSurroundingQuotes(joined);
+                        }
+
+                        return null;
+                    }
+
                     var stringValue = value.ToString();
                     if (!string.IsNullOrEmpty(stringValue))
                     {

--- a/Jellyfin.Plugin.MusicTags/MusicTagService.cs
+++ b/Jellyfin.Plugin.MusicTags/MusicTagService.cs
@@ -570,6 +570,13 @@ public class MusicTagService(
                     // Handle array types (e.g. Artists, Performers, Genres return string[])
                     if (value is string[] stringArray)
                     {
+                        _logger.LogDebug(
+                            "ExtractGenericTag: property '{PropertyName}' returned {ValueType} with {Count} item(s): [{Items}]",
+                            property.Name,
+                            value.GetType().Name,
+                            stringArray.Length,
+                            string.Join(", ", stringArray.Select(s => s ?? "<null>")));
+
                         var joined = string.Join("; ", stringArray.Where(s => !string.IsNullOrEmpty(s)));
                         if (!string.IsNullOrEmpty(joined))
                         {

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jellyfin:
-    image: jellyfin/jellyfin:10.11.4
+    image: jellyfin/jellyfin:10.11.6
     container_name: jellyfin
     user: 1000:1000
     ports:


### PR DESCRIPTION
Closes https://github.com/jyourstone/jellyfin-musictags-plugin/issues/21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-value music tags (artists, performers, genres) now display correctly by joining array entries into a clean, semicolon-separated string and omitting empty items.

* **Chores**
  * Updated Jellyfin Docker image base from version 10.11.4 to 10.11.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->