### PR TITLE
Enhance ID3v2 frame handling with fallback support for version compatibility

### DIFF
--- a/Jellyfin.Plugin.MusicTags/MusicTagService.cs
+++ b/Jellyfin.Plugin.MusicTags/MusicTagService.cs
@@ -70,6 +70,7 @@ public class MusicTagService(
         { "ORIGINALALBUM", "TOAL" },
         { "ORIGINALFILENAME", "TOFN" },
         { "ORIGINALYEAR", "TORY" },
+        { "ORIGYEAR", "TORY" },        // Mp3tag alias for ORIGINALYEAR
         { "ORIGINALDATE", "TDOR" },
         { "ORIGINALLYRICIST", "TOLY" },
         
@@ -100,6 +101,18 @@ public class MusicTagService(
         
         // Playlist delay
         { "PLAYLISTDELAY", "TDLY" },
+    };
+
+    /// <summary>
+    /// Fallback frame IDs for ID3v2 version compatibility.
+    /// Some frames changed between ID3v2.3 and ID3v2.4 (e.g., TORY became TDOR).
+    /// When the primary frame yields no result, the fallback is tried automatically
+    /// so users don't need to know which ID3 version their files use.
+    /// </summary>
+    private static readonly Dictionary<string, string> FrameIdFallbacks = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "TORY", "TDOR" },  // ID3v2.3 original year -> ID3v2.4 original date
+        { "TDOR", "TORY" },  // ID3v2.4 original date -> ID3v2.3 original year
     };
 
     /// <summary>
@@ -867,6 +880,16 @@ public class MusicTagService(
                 if (!string.IsNullOrEmpty(mappedResult))
                 {
                     return mappedResult;
+                }
+
+                // Try the fallback frame for cross-version compatibility (e.g., TORY <-> TDOR)
+                if (FrameIdFallbacks.TryGetValue(frameId, out var fallbackFrameId))
+                {
+                    var fallbackResult = ExtractId3v2TextFrame(file, fallbackFrameId);
+                    if (!string.IsNullOrEmpty(fallbackResult))
+                    {
+                        return fallbackResult;
+                    }
                 }
             }
 


### PR DESCRIPTION
- Added a new alias for the ORIGINALYEAR tag as ORIGYEAR to support Mp3tag.
- Introduced a static dictionary for fallback frame IDs to ensure compatibility between ID3v2.3 and ID3v2.4, allowing automatic fallback during tag extraction.
- Updated the tag extraction logic to utilize fallback frames, improving reliability for users with mixed ID3 versions.

This change enhances the plugin's ability to handle various ID3 versions seamlessly, ensuring better metadata extraction across different audio files.

https://github.com/jyourstone/jellyfin-musictags-plugin/issues/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music tag extraction with enhanced compatibility for alternate ID3v2 frame formats. Added fallback mechanisms for metadata retrieval to ensure custom tags are properly extracted even when primary frame lookups don't yield results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->