### PR TITLE
Extracts every value from multi-value tags instead of only the first one, so delimiter splitting produces all expected Jellyfin tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,4 @@ dev/media/
 
 # Mac
 .DS_Store
+primer.md

--- a/Jellyfin.Plugin.MusicTags/MusicTagService.cs
+++ b/Jellyfin.Plugin.MusicTags/MusicTagService.cs
@@ -586,13 +586,14 @@ public class MusicTagService(
     /// <returns>All comment values joined with "; ", or null if none found.</returns>
     private string? ExtractAllComments(TagLib.File file)
     {
-        var values = new List<string>();
+        List<string> values = [];
 
         // ID3v2 (MP3): gather every COMM frame, not just the first
         if (file.GetTag(TagLib.TagTypes.Id3v2) is TagLib.Id3v2.Tag id3Tag)
         {
             foreach (var frame in id3Tag.GetFrames<TagLib.Id3v2.CommentsFrame>())
             {
+                _logger.LogDebug("Found ID3v2 COMM frame: desc='{Description}', text='{Text}'", frame.Description, frame.Text);
                 if (!string.IsNullOrWhiteSpace(frame.Text))
                 {
                     values.Add(frame.Text.Trim());
@@ -605,6 +606,7 @@ public class MusicTagService(
         {
             foreach (var value in vorbisTag.GetField("COMMENT"))
             {
+                _logger.LogDebug("Found Vorbis COMMENT field: '{Value}'", value);
                 if (!string.IsNullOrWhiteSpace(value))
                 {
                     values.Add(value.Trim());

--- a/Jellyfin.Plugin.MusicTags/MusicTagService.cs
+++ b/Jellyfin.Plugin.MusicTags/MusicTagService.cs
@@ -529,15 +529,15 @@ public class MusicTagService(
             // First try standard TagLib properties for common tags
             var result = cleanTagName switch
             {
-                "ARTIST" => !string.IsNullOrEmpty(file.Tag.FirstPerformer) ? file.Tag.FirstPerformer : null,
+                "ARTIST" => JoinTagValues(file.Tag.Performers),
                 "ALBUM" => !string.IsNullOrEmpty(file.Tag.Album) ? file.Tag.Album : null,
-                "GENRE" => !string.IsNullOrEmpty(file.Tag.FirstGenre) ? file.Tag.FirstGenre : null,
+                "GENRE" => JoinTagValues(file.Tag.Genres),
                 "YEAR" => file.Tag.Year > 0 ? file.Tag.Year.ToString(CultureInfo.InvariantCulture) : null,
-                "COMPOSER" => !string.IsNullOrEmpty(file.Tag.FirstComposer) ? file.Tag.FirstComposer : null,
+                "COMPOSER" => JoinTagValues(file.Tag.Composers),
                 "BPM" => file.Tag.BeatsPerMinute > 0 ? file.Tag.BeatsPerMinute.ToString() : null,
                 "PUBLISHER" => !string.IsNullOrEmpty(file.Tag.Publisher) ? file.Tag.Publisher : null,
                 "COPYRIGHT" => !string.IsNullOrEmpty(file.Tag.Copyright) ? file.Tag.Copyright : null,
-                "COMMENT" => !string.IsNullOrEmpty(file.Tag.Comment) ? file.Tag.Comment : null,
+                "COMMENT" => ExtractAllComments(file),
                 "KEY" => ExtractKeyTag(file),
                 "MOOD" => ExtractId3v2TextFrame(file, "TMOO"),
                 "LANGUAGE" => ExtractId3v2TextFrame(file, "TLAN"),
@@ -558,6 +558,69 @@ public class MusicTagService(
             _logger.LogWarning(ex, "Error extracting tag value for {TagName}", tagName);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Joins a multi-value tag array into a single string using "; " so that
+    /// SplitTagValue can split it back into separate tags via configured delimiters.
+    /// </summary>
+    /// <param name="values">The tag values.</param>
+    /// <returns>The joined value, or null if the array has no non-empty values.</returns>
+    private static string? JoinTagValues(string[]? values)
+    {
+        if (values == null || values.Length == 0)
+        {
+            return null;
+        }
+
+        var joined = string.Join("; ", values.Where(v => !string.IsNullOrWhiteSpace(v)).Select(v => v.Trim()).Distinct());
+        return string.IsNullOrEmpty(joined) ? null : joined;
+    }
+
+    /// <summary>
+    /// Extracts all comment values from the audio file.
+    /// Multi-value comments are stored as multiple ID3v2 COMM frames or repeated
+    /// Vorbis COMMENT fields; the TagLib convenience property only returns the first one.
+    /// </summary>
+    /// <param name="file">The TagLib file.</param>
+    /// <returns>All comment values joined with "; ", or null if none found.</returns>
+    private string? ExtractAllComments(TagLib.File file)
+    {
+        var values = new List<string>();
+
+        // ID3v2 (MP3): gather every COMM frame, not just the first
+        if (file.GetTag(TagLib.TagTypes.Id3v2) is TagLib.Id3v2.Tag id3Tag)
+        {
+            foreach (var frame in id3Tag.GetFrames<TagLib.Id3v2.CommentsFrame>())
+            {
+                if (!string.IsNullOrWhiteSpace(frame.Text))
+                {
+                    values.Add(frame.Text.Trim());
+                }
+            }
+        }
+
+        // Vorbis comments (FLAC/OGG): COMMENT can appear as repeated fields
+        if (file.GetTag(TagLib.TagTypes.Xiph) is TagLib.Ogg.XiphComment vorbisTag)
+        {
+            foreach (var value in vorbisTag.GetField("COMMENT"))
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    values.Add(value.Trim());
+                }
+            }
+        }
+
+        if (values.Count == 0)
+        {
+            // Other containers (M4A, ASF, APE): fall back to the convenience property
+            return !string.IsNullOrEmpty(file.Tag.Comment) ? file.Tag.Comment : null;
+        }
+
+        var result = string.Join("; ", values.Distinct());
+        _logger.LogDebug("Extracted {Count} comment value(s): '{Result}'", values.Count, result);
+        return result;
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The configuration page allows you to:
    - Automatically splits tag values containing these delimiters into multiple tags
    - Perfect for multi-genre tracks, parental controls, and instant mix functionality
    - Leave empty to disable splitting
+   - Tags stored as true multi-value fields (multiple ID3v2 COMM frames or repeated Vorbis comment fields) are also extracted in full — add `;` to the delimiters to split them into separate tags
 
 3. **Tag Names to Remove**: Remove unwanted tags from your Jellyfin library
    - Comma-separated list of tag names to remove (e.g., "BPM,KEY")


### PR DESCRIPTION
## What
Extracts every value from multi-value tags instead of only the first one, so delimiter splitting produces all expected Jellyfin tags.

## Why
Fixes #25. A comment stored as a true multi-value field (e.g. two values shown as `first;second;` in a tag editor) only produced `Comment:first` in Jellyfin. Root cause: TagLib's convenience properties (`Comment`, `FirstPerformer`, `FirstGenre`, `FirstComposer`) return only the first value when a file stores multiple ID3v2 COMM frames or repeated Vorbis COMMENT fields — the remaining values never reached the delimiter-splitting logic (which itself worked fine).

## Changes
- Added `ExtractAllComments()`: gathers all ID3v2 COMM frames and all Vorbis COMMENT fields, joins with `"; "` (same convention as #22), falls back to `file.Tag.Comment` for other containers (M4A/ASF/APE)
- Added `JoinTagValues()` helper; `ARTIST`, `GENRE`, and `COMPOSER` now use the full `Performers`/`Genres`/`Composers` arrays instead of `First*` — same first-value-only bug family
- README: documented multi-value field extraction under the delimiter settings
- Verified against generated test files (MP3 with two COMM frames, FLAC with two COMMENT fields, plus literal-semicolon controls) in the local dev environment

## Known limitation
Multiple values stored null-separated inside a **single** COMM frame are dropped by TagLibSharp itself during parsing (`CommentsFrame.ParseFields` keeps only the first text segment), so they cannot be recovered without reimplementing ID3 parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3ZJ7BRt3nALToWgC4JQr4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved music tag extraction for artists, genres, composers, and comments stored with multiple values.
  * Multiple tag values are now combined, cleaned, and deduplicated for more complete metadata.

* **Documentation**
  * Clarified how multi-value tags are extracted and how delimiters can split them into separate Jellyfin tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->